### PR TITLE
Docs link and tag regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Fritz SDK is used to provide insights into your use of Core ML models. Fritz
 
 ## Documentation
 
-[https://fritzlabs.github.io/swift-framework/](https://fritzlabs.github.io/swift-framework/)
+[https://docs.fritz.ai/iOS/latest/](https://docs.fritz.ai/iOS/latest/)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Fritz SDK is used to provide insights into your use of Core ML models. Fritz
 
 ## Documentation
 
-[https://docs.fritz.ai/iOS/latest/](https://docs.fritz.ai/iOS/latest/)
+[https://docs.fritz.ai/iOS/latest/index.html](https://docs.fritz.ai/iOS/latest/index.html)
 
 ## Installation
 

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -3,4 +3,4 @@
   command: deploy/deploy.sh
   cached: true
   # regex matches 1.2.3 and 1.2.3-beta type formats
-  tag: ^(\d+\.)(\d+\.)(\*|\d+)(-\w+)?$
+  tag: ^(\d+\.)?(\d+\.)?(\d+)(-\w+\.?\w+)?$

--- a/deploy/redirect.html
+++ b/deploy/redirect.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Fritz iOS Docs</title>
-    <meta http-equiv="refresh" content="0;URL='https://docs.fritz.ai/docs/iOS/CI_BRANCH/'" />
+    <meta http-equiv="refresh" content="0;URL='https://docs.fritz.ai/docs/iOS/CI_BRANCH/index.html'" />
     <link rel="stylesheet" href="https://cdn.fritz.ai/css/font-sf-display.css" type="text/css" />
     <link rel="stylesheet" href="https://cdn.fritz.ai/css/redirect.css" type="text/css" />
     <link rel="shortcut icon" href="https://cdn.fritz.ai/favicons/fritz.ico" />

--- a/deploy/redirect.html
+++ b/deploy/redirect.html
@@ -7,6 +7,6 @@
     <link rel="shortcut icon" href="https://cdn.fritz.ai/favicons/fritz.ico" />
   </head>
   <body>
-    <p><a href="https://docs.fritz.ai/docs/iOS/CI_BRANCH/">This page has moved</a></p>
+    <p><a href="https://docs.fritz.ai/iOS/CI_BRANCH/index.html">This page has moved</a></p>
   </body>
 </html>


### PR DESCRIPTION
Updates link to iOS SDK docs.

Fixes redirect path.

Fixes regex to handle SemVer format.
