### PR TITLE
Include the encrypted model build script in the pod

### DIFF
--- a/Fritz.podspec
+++ b/Fritz.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.subspec 'ManagedModel' do |analytics|
     analytics.dependency 'Fritz/Core'
     analytics.vendored_framework = 'Frameworks/FritzManagedModel.framework'
+    analytics.preserve_path = 'Frameworks/FritzManagedModel.framework/build-encrypted-model.sh'
   end
 
   s.subspec 'Core' do |core|


### PR DESCRIPTION
We weren't actually preserving the path of the build script in the released version of fritz. Need to do that.