### PR TITLE
redirect docs

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,5 +1,4 @@
 name: Build Jazzy docs
-
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -1,10 +1,10 @@
 name: Deploy Jazzy docs
 on:
+  workflow_dispatch:
   push:
     tags: "*"
 env:
   BUILD_DIR: /tmp/build
-
 
 jobs:
   ios-docs-deploy:

--- a/deploy/redirect.html
+++ b/deploy/redirect.html
@@ -1,12 +1,12 @@
 <html>
   <head>
     <title>Fritz iOS Docs</title>
-    <meta http-equiv="refresh" content="0;URL='https://docs.fritz.ai/iOS/CI_BRANCH/index.html'" />
+    <meta http-equiv="refresh" content="0;URL='https://api-reference.fritz.ai/iOS/CI_BRANCH/index.html'" />
     <link rel="stylesheet" href="https://cdn.fritz.ai/css/font-sf-display.css" type="text/css" />
     <link rel="stylesheet" href="https://cdn.fritz.ai/css/redirect.css" type="text/css" />
     <link rel="shortcut icon" href="https://cdn.fritz.ai/favicons/fritz.ico" />
   </head>
   <body>
-    <p><a href="https://docs.fritz.ai/iOS/CI_BRANCH/index.html">This page has moved</a></p>
+    <p><a href="https://api-reference.fritz.ai/iOS/CI_BRANCH/index.html">This page has moved</a></p>
   </body>
 </html>


### PR DESCRIPTION
Docs deploy worked, but now points to a 404 page. Should just need to change the deploy URL. Will trigger the deploy action again.